### PR TITLE
Add user roles and agritherapy options to setup wizard

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -2,5 +2,7 @@
 
 1. Flash Raspberry Pi OS and boot the device.
 2. Clone this repository and run `sudo ./setup/wizard.sh`.
-3. Follow the prompts to select your role (educator, technician, etc.), primary goal, hardware complexity, and privacy preference.
-4. After completion, view `config/user_choices.json` for a summary of your selections.
+3. Follow the prompts to select your role (educator, technician, farmer, researcher, therapist, agritherapist, or community organizer).
+4. If you choose a therapeutic role you will be asked about therapy type and any accessibility accommodations.
+5. You may also enable optional photo journaling for plant documentation. When data is collected or photos are taken, the wizard will ask you to confirm participant consent.
+6. After completion, view `config/user_choices.json` for a summary of your selections.

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,6 +1,6 @@
 # Setup Wizard
 
-This folder contains the modular `wizard.sh` script and supporting files for configuring a Raspberry Pi based controlled environment system. The wizard is designed for non-technical users and walks through selecting a role, goal, hardware complexity, and privacy level.
+This folder contains the modular `wizard.sh` script and supporting files for configuring a Raspberry Pi based controlled environment system. The wizard is designed for non-technical users and walks through selecting a role, goal, hardware complexity, privacy level, and optional agritherapy settings.
 
 Run the wizard from the repository root:
 
@@ -8,4 +8,4 @@ Run the wizard from the repository root:
 sudo ./setup/wizard.sh
 ```
 
-The script records your selections to `config/user_choices.json` for later integration with dashboards or automation tools. To extend the wizard, edit or add functions in `wizard.sh`.
+The script records your selections to `config/user_choices.json` for later integration with dashboards or automation tools. Therapeutic roles include questions about therapy type and accessibility accommodations. To extend the wizard, edit or add functions in `wizard.sh`.

--- a/setup/wizard.sh
+++ b/setup/wizard.sh
@@ -11,11 +11,19 @@ choose_role() {
   echo "1) Educator"
   echo "2) Technician"
   echo "3) Farmer"
-  read -p "Choice [1-3]: " ans
+  echo "4) Researcher"
+  echo "5) Therapist"
+  echo "6) Agritherapist"
+  echo "7) Community Organizer"
+  read -p "Choice [1-7]: " ans
   case $ans in
     1) ROLE="educator" ;;
     2) ROLE="technician" ;;
     3) ROLE="farmer" ;;
+    4) ROLE="researcher" ;;
+    5) ROLE="therapist" ;;
+    6) ROLE="agritherapist" ;;
+    7) ROLE="community" ;;
     *) ROLE="general" ;;
   esac
 }
@@ -32,6 +40,33 @@ choose_goal() {
     3) GOAL="research" ;;
     *) GOAL="demo" ;;
   esac
+}
+
+choose_learning_goal() {
+  if [ "$ROLE" = "educator" ] || [ "$ROLE" = "therapist" ] || [ "$ROLE" = "agritherapist" ]; then
+    read -p "Learning or therapy goal (optional): " LEARNING_GOAL
+  fi
+}
+
+choose_therapy_options() {
+  if [ "$ROLE" = "agritherapist" ] || [ "$ROLE" = "therapist" ]; then
+    read -p "Therapy type (group/individual): " THERAPY_TYPE
+    read -p "Accessibility accommodations needed? (y/n): " ACCESS_NEEDED
+    if [[ "$ACCESS_NEEDED" =~ ^[yY]$ ]]; then
+      echo "1) Visual impairments"
+      echo "2) Motor limitations"
+      echo "3) Cognitive"
+      echo "4) Multiple"
+      read -p "Select accommodation [1-4]: " acc
+      case $acc in
+        1) ACCOMMODATION="visual" ;;
+        2) ACCOMMODATION="motor" ;;
+        3) ACCOMMODATION="cognitive" ;;
+        4) ACCOMMODATION="multiple" ;;
+        *) ACCOMMODATION="general" ;;
+      esac
+    fi
+  fi
 }
 
 choose_hardware() {
@@ -56,6 +91,17 @@ choose_privacy() {
   esac
 }
 
+choose_photo_journaling() {
+  read -p "Enable daily photo journaling? (y/n): " PHOTO_JOURNAL
+}
+
+consent_reminder() {
+  if [[ "$PRIVACY" != "local" || "$PHOTO_JOURNAL" =~ ^[yY]$ ]]; then
+    echo "Data collection features selected." 
+    read -p "Confirm all participants are informed (y/n): " CONSENT_CONFIRMED
+  fi
+}
+
 save_config() {
   mkdir -p "$(dirname "$CONFIG_LOG")"
   cat > "$CONFIG_LOG" <<EOC
@@ -63,7 +109,12 @@ save_config() {
   "user_role": "$ROLE",
   "primary_goal": "$GOAL",
   "system_type": "$HARDWARE",
-  "privacy_mode": "$PRIVACY"
+  "privacy_mode": "$PRIVACY",
+  "learning_goal": "$LEARNING_GOAL",
+  "therapy_type": "$THERAPY_TYPE",
+  "accommodation": "$ACCOMMODATION",
+  "photo_journaling": "$PHOTO_JOURNAL",
+  "consent_confirmed": "$CONSENT_CONFIRMED"
 }
 EOC
   echo "Configuration saved to $CONFIG_LOG"
@@ -72,8 +123,12 @@ EOC
 main() {
   choose_role
   choose_goal
+  choose_learning_goal
+  choose_therapy_options
   choose_hardware
   choose_privacy
+  choose_photo_journaling
+  consent_reminder
   save_config
 }
 


### PR DESCRIPTION
## Summary
- expand `setup/wizard.sh` with additional user roles
- add learning goal and therapy questions
- include photo journaling and consent prompts
- save the new settings to `user_choices.json`
- update docs to describe the new wizard features

## Testing
- `bash -n setup/wizard.sh`