### PR TITLE
Add micro setup, Docker files, and REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ REPOSITORY STRUCTURE
 - rpi_scripts/: Raspberry Pi helper scripts
 - dashboards/: dashboard templates
 - docs/: documentation
+- api/: lightweight REST API
+- docker/: containerization files
 
 KEY FEATURES
 
@@ -99,6 +101,8 @@ Quick Start Installation
 5. Follow the interactive prompts to configure your system
 6. Complete hardware connections based on your selected configuration
 7. Access the web interface at your Raspberry Pi's IP address
+
+For a minimal temperature and humidity monitor, run `sudo ./micro_monitoring_setup.sh`.
 
 The setup wizard will automatically:
 - Update your system packages
@@ -243,6 +247,8 @@ Hydroponic System Setup
 
 Safety considerations are built into all configurations with special attention to educational and therapeutic environments.
 
+Starter kits are available to simplify hardware selection; see `docs/hardware_starter_kits.md` for details.
+
 SOFTWARE ARCHITECTURE
 
 The system utilizes a layered architecture:
@@ -292,6 +298,7 @@ Data Export
 - PDF report generation
 - Photo documentation packages
 - System configuration backups
+- REST API for integrations
 
 Privacy Controls
 - Granular data sharing controls
@@ -401,6 +408,8 @@ Documentation
 - Comprehensive setup guides
 - Hardware compatibility lists
 - Troubleshooting procedures
+- Regional adaptation guides
+- Docker usage instructions
 - Best practices documentation
 
 Community Support

--- a/api/rest_api.py
+++ b/api/rest_api.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Container Farm Control System - REST API
+This lightweight API exposes sensor readings and simple
+control commands from the local system. It is intended
+as a foundation for mobile apps or third party services.
+"""
+
+from flask import Flask, jsonify, request
+import json
+import os
+
+app = Flask(__name__)
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), '..', 'config', 'user_choices.json')
+
+
+def load_data():
+    """Load sensor data from a JSON file (placeholder)."""
+    if not os.path.exists(DATA_FILE):
+        return {}
+    with open(DATA_FILE, 'r') as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+
+
+@app.route('/api/status', methods=['GET'])
+def status():
+    """Return basic system status."""
+    data = load_data()
+    return jsonify({
+        'status': 'ok',
+        'data': data
+    })
+
+
+@app.route('/api/control/<string:output>', methods=['POST'])
+def control(output):
+    """Placeholder route to toggle an output."""
+    action = request.json.get('action', 'toggle')
+    # This is only a placeholder; real implementation would
+    # interface with Mycodo or GPIO to control hardware.
+    return jsonify({
+        'output': output,
+        'action': action,
+        'success': True
+    })
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy project files
+COPY .. /app
+WORKDIR /app
+
+# Install Python dependencies (basic)
+RUN pip install --no-cache-dir flask
+
+EXPOSE 5000
+CMD ["python", "api/rest_api.py"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  farm-api:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - ../config:/app/config

--- a/docs/docker_support.md
+++ b/docs/docker_support.md
@@ -1,0 +1,10 @@
+# Docker Support
+
+This project includes a lightweight Docker setup for the REST API. Build and run with:
+
+```bash
+cd docker
+docker compose up --build
+```
+
+The container exposes port `5000` for API access. Configuration files in `config/` are mounted into the container for read-only access.

--- a/docs/hardware_starter_kits.md
+++ b/docs/hardware_starter_kits.md
@@ -1,0 +1,10 @@
+# Hardware Starter Kits
+
+Pre-configured starter kits simplify hardware setup. Use `hardware_kit_integration.sh` to list and apply kits.
+
+```bash
+sudo ./hardware_kit_integration.sh --list
+sudo ./hardware_kit_integration.sh --set <kit_id>
+```
+
+Each kit includes a pin map and optional QR code for quick configuration.

--- a/docs/regional_adaptation.md
+++ b/docs/regional_adaptation.md
@@ -1,0 +1,7 @@
+# Regional Adaptation Guides
+
+Growing conditions vary by region. Document your local climate adjustments and share them with the community.
+
+- Adjust temperature set points for your climate zone.
+- Modify lighting schedules for day length differences.
+- Share crop recommendations for your area.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,9 @@
+# Troubleshooting
+
+Common issues and solutions are collected here. Contributions are welcome.
+
+- **Sensors not detected**: Check wiring and I2C/1-Wire interfaces.
+- **Mycodo not starting**: Review `/var/log/mycodo/` for errors.
+- **Permission errors**: Ensure the `mycodo` user is in the required groups (`gpio`, `i2c`, `dialout`).
+
+If you resolve an issue, please submit a pull request to expand this guide.

--- a/docs/use_case_showcases.md
+++ b/docs/use_case_showcases.md
@@ -1,0 +1,8 @@
+# Use Case Showcases
+
+Real-world examples help newcomers understand what is possible. Submit photos and descriptions of your deployments via pull request or the discussion forum.
+
+Suggested details:
+- Photos of the installation
+- Configuration used
+- Outcomes or lessons learned

--- a/micro_monitoring_setup.sh
+++ b/micro_monitoring_setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Container Farm Control System - Micro Monitoring Setup
+# Simplified installer for temperature and humidity monitoring only.
+
+set -e
+
+CONFIG_FILE="basic_monitoring.json"
+INSTALL_DIR="/opt/container-farm-control"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Please run as root (sudo)." >&2
+  exit 1
+fi
+
+# Create install directory
+mkdir -p "$INSTALL_DIR"
+cp "$CONFIG_FILE" "$INSTALL_DIR/"
+
+echo "Installing required packages..."
+apt-get update
+apt-get install -y git python3 python3-pip
+
+# Install Mycodo (minimal)
+if ! command -v mycodo-client >/dev/null; then
+  curl -L https://kizniche.github.io/mycodo-installer/install | bash
+fi
+
+# Import configuration
+if [ -f /var/mycodo/databases/mycodo.db ]; then
+  echo "Importing basic monitoring configuration..."
+  mycodo-client --import "$INSTALL_DIR/$CONFIG_FILE"
+  systemctl restart mycododaemon
+fi
+
+echo "Micro monitoring setup complete. Access the dashboard at http://<pi-ip>:8080"
+


### PR DESCRIPTION
## Summary
- document new repo directories
- include quick micro monitoring install option
- add REST API skeleton
- provide Docker container setup
- add docs for regional adaptation, hardware kits, troubleshooting, use case showcases

## Testing
- `python3 -m py_compile api/rest_api.py`
- `shellcheck micro_monitoring_setup.sh` *(fails: command not found)*