### PR TITLE
Add simple API auth and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ REPOSITORY STRUCTURE
 - rpi_scripts/: Raspberry Pi helper scripts
 - dashboards/: dashboard templates
 - docs/: documentation
-- api/: lightweight REST API
+- api/: lightweight REST API with docs in `api/docs/`
 - docker/: containerization files
 
 KEY FEATURES
@@ -299,6 +299,7 @@ Data Export
 - Photo documentation packages
 - System configuration backups
 - REST API for integrations
+- See `api/docs/openapi.yaml` for the API specification
 
 Privacy Controls
 - Granular data sharing controls

--- a/api/docs/authentication.md
+++ b/api/docs/authentication.md
@@ -1,0 +1,11 @@
+# API Authentication
+
+All API requests require an API key provided via the `X-API-Key` header.
+
+Example using `curl`:
+
+```bash
+curl -H "X-API-Key: YOUR_KEY" http://localhost:5000/api/status
+```
+
+Generate a key and set it as the environment variable `API_KEY` before starting the API server.

--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.0
+info:
+  title: Container Farm Control API
+  version: "1.0"
+servers:
+  - url: http://localhost:5000
+paths:
+  /api/status:
+    get:
+      summary: Get basic system status
+      responses:
+        '200':
+          description: Status response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    type: object
+      security:
+        - ApiKeyAuth: []
+  /api/control/{output}:
+    post:
+      summary: Control a specific output
+      parameters:
+        - in: path
+          name: output
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                action:
+                  type: string
+                  default: toggle
+      responses:
+        '200':
+          description: Control response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  output:
+                    type: string
+                  action:
+                    type: string
+                  success:
+                    type: boolean
+      security:
+        - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,0 +1,15 @@
+from functools import wraps
+from flask import request, abort
+import os
+
+API_KEY = os.environ.get("API_KEY")
+
+def require_api_key(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if API_KEY:
+            provided = request.headers.get("X-API-Key")
+            if not provided or provided != API_KEY:
+                abort(401)
+        return func(*args, **kwargs)
+    return wrapper

--- a/api/rest_api.py
+++ b/api/rest_api.py
@@ -9,6 +9,7 @@ as a foundation for mobile apps or third party services.
 from flask import Flask, jsonify, request
 import json
 import os
+from middleware.auth import require_api_key
 
 app = Flask(__name__)
 
@@ -27,6 +28,7 @@ def load_data():
 
 
 @app.route('/api/status', methods=['GET'])
+@require_api_key
 def status():
     """Return basic system status."""
     data = load_data()
@@ -37,6 +39,7 @@ def status():
 
 
 @app.route('/api/control/<string:output>', methods=['POST'])
+@require_api_key
 def control(output):
     """Placeholder route to toggle an output."""
     action = request.json.get('action', 'toggle')


### PR DESCRIPTION
## Summary
- secure API endpoints with an API key
- document API authentication and spec
- mention new docs in README

## Testing
- `python3 -m py_compile api/rest_api.py api/middleware/auth.py`
