### PR TITLE
Add API security layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ REPOSITORY STRUCTURE
 - rpi_scripts/: Raspberry Pi helper scripts
 - dashboards/: dashboard templates
 - docs/: documentation
-- api/: lightweight REST API
+- api/: lightweight REST API with docs in `api/docs/` (see security notes)
 - docker/: containerization files
 
 KEY FEATURES
@@ -299,6 +299,10 @@ Data Export
 - Photo documentation packages
 - System configuration backups
 - REST API for integrations
+- See `api/docs/openapi.yaml` for the API specification
+- See `api/docs/security.md` for authentication and rate limit details
+- API requests require an `X-API-Key` header and are limited to 60
+  requests per minute. Invalid control actions are rejected with `400`.
 
 Privacy Controls
 - Granular data sharing controls

--- a/api/docs/authentication.md
+++ b/api/docs/authentication.md
@@ -1,0 +1,11 @@
+# API Authentication
+
+All API requests require an API key provided via the `X-API-Key` header.
+
+Example using `curl`:
+
+```bash
+curl -H "X-API-Key: YOUR_KEY" http://localhost:5000/api/status
+```
+
+Generate a key and set it as the environment variable `API_KEY` before starting the API server.

--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.0
+info:
+  title: Container Farm Control API
+  version: "1.0"
+servers:
+  - url: http://localhost:5000
+paths:
+  /api/status:
+    get:
+      summary: Get basic system status
+      responses:
+        '200':
+          description: Status response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    type: object
+        '429':
+          description: Too many requests
+      security:
+        - ApiKeyAuth: []
+  /api/control/{output}:
+    post:
+      summary: Control a specific output
+      parameters:
+        - in: path
+          name: output
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                action:
+                  type: string
+                  default: toggle
+      responses:
+        '200':
+          description: Control response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  output:
+                    type: string
+                  action:
+                    type: string
+                  success:
+                    type: boolean
+        '400':
+          description: Invalid request
+        '429':
+          description: Too many requests
+      security:
+        - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key

--- a/api/docs/security.md
+++ b/api/docs/security.md
@@ -1,0 +1,17 @@
+# API Security
+
+The REST API includes several lightweight protections:
+
+- **API key authentication** via the `X-API-Key` header.
+- **Rate limiting** of 60 requests per minute per IP address.
+- **Input validation** for control actions (`toggle`, `on`, `off`).
+
+Set an API key before starting the server:
+
+```bash
+export API_KEY=mysecret
+python api/rest_api.py
+```
+
+Requests exceeding the rate limit will receive an HTTP `429` response.
+Invalid or missing actions on `/api/control/{output}` return `400`.

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,0 +1,15 @@
+from functools import wraps
+from flask import request, abort
+import os
+
+API_KEY = os.environ.get("API_KEY")
+
+def require_api_key(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if API_KEY:
+            provided = request.headers.get("X-API-Key")
+            if not provided or provided != API_KEY:
+                abort(401)
+        return func(*args, **kwargs)
+    return wrapper

--- a/api/middleware/rate_limiting.py
+++ b/api/middleware/rate_limiting.py
@@ -1,0 +1,33 @@
+import time
+from functools import wraps
+from flask import request, abort
+
+# Simple in-memory rate limiting
+REQUEST_LIMIT = 60  # requests
+WINDOW_SIZE = 60  # seconds
+
+# Dictionary to store request counters per IP
+_request_log = {}
+
+
+def rate_limit(func):
+    """Limit the number of requests per IP address."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        ip = request.remote_addr or 'anonymous'
+        now = time.time()
+        entry = _request_log.get(ip)
+        if entry:
+            count, first_ts = entry
+            if now - first_ts <= WINDOW_SIZE:
+                if count >= REQUEST_LIMIT:
+                    abort(429)
+                _request_log[ip] = (count + 1, first_ts)
+            else:
+                _request_log[ip] = (1, now)
+        else:
+            _request_log[ip] = (1, now)
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/api/middleware/validation.py
+++ b/api/middleware/validation.py
@@ -1,0 +1,30 @@
+from functools import wraps
+from flask import request, abort
+
+ALLOWED_ACTIONS = {'toggle', 'on', 'off'}
+
+
+def require_json(func):
+    """Ensure the request contains JSON."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not request.is_json:
+            abort(400)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def validate_control_action(func):
+    """Validate action field for /api/control."""
+
+    @wraps(func)
+    def wrapper(output, *args, **kwargs):
+        data = request.get_json() or {}
+        action = data.get('action', 'toggle')
+        if action not in ALLOWED_ACTIONS:
+            abort(400)
+        return func(output, *args, **kwargs)
+
+    return wrapper

--- a/api/rest_api.py
+++ b/api/rest_api.py
@@ -9,6 +9,9 @@ as a foundation for mobile apps or third party services.
 from flask import Flask, jsonify, request
 import json
 import os
+from middleware.auth import require_api_key
+from middleware.rate_limiting import rate_limit
+from middleware.validation import require_json, validate_control_action
 
 app = Flask(__name__)
 
@@ -27,6 +30,8 @@ def load_data():
 
 
 @app.route('/api/status', methods=['GET'])
+@require_api_key
+@rate_limit
 def status():
     """Return basic system status."""
     data = load_data()
@@ -37,9 +42,13 @@ def status():
 
 
 @app.route('/api/control/<string:output>', methods=['POST'])
+@require_api_key
+@rate_limit
+@require_json
+@validate_control_action
 def control(output):
     """Placeholder route to toggle an output."""
-    action = request.json.get('action', 'toggle')
+    action = request.get_json().get('action', 'toggle')
     # This is only a placeholder; real implementation would
     # interface with Mycodo or GPIO to control hardware.
     return jsonify({


### PR DESCRIPTION
## Summary
- document API security in new `api/docs/security.md`
- mention security docs in README
- add simple rate limiting and validation middleware
- update REST API to use security middleware
- note security requirements in API reference

## Testing
- `python3 -m py_compile api/rest_api.py api/middleware/auth.py api/middleware/rate_limiting.py api/middleware/validation.py`
