### PR TITLE
Fix syntax issue in PulseMesh

### DIFF
--- a/PulseMesh.py
+++ b/PulseMesh.py
@@ -2540,10 +2540,6 @@ class PulseMeshFederatedNode:
             "success": True,
             "node_count": len(nodes),
             "nodes": nodes,
-            "timestamp return {
-            "success": True,
-            "node_count": len(nodes),
-            "nodes": nodes,
             "timestamp": time.time()
         }
     


### PR DESCRIPTION
## Summary
- fix malformed return block in `get_distributed_nodes`

## Testing
- `python -m py_compile PulseMesh.py`
- `python - <<'EOF'
import compileall, sys
success = compileall.compile_dir('.', quiet=1)
sys.exit(0 if success else 1)
EOF` *(fails: FreightFarmHarmony.py, GaiaBioregionalHarmony.py, GaiaEcoSystem.py)*