### PR TITLE
Integrate quantum modules into core

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ curl -sSL https://raw.githubusercontent.com/HydroFarmerJason/OpenSourceControlle
   - Frequency-domain agent coordination via FFT
   - Bridges digital decisions with physical actions
   - Demonstration: `osce-hivemind-fft.py`
+ - Advanced modules: `osce.core.living_quantum_monitor` and `osce.core.planetary_optimizer_v3`
 
 ###  Interface Options
 
@@ -189,6 +190,8 @@ Explore advanced functionality using the scripts in the repository root:
 - `osce_unified_setup.py` – Production-ready setup leveraging the IoT Abstract Resource Model.
 - `osce_hal_enhanced.py` – Enhanced hardware abstraction layer with monitoring and security.
 - `osce_complete_example.py` – Comprehensive demonstration of a multi-site deployment.
+- `osce.core.living_quantum_monitor` – Evidence-led monitoring for quantum CEA experiments.
+- `osce.core.planetary_optimizer_v3` – Distributed, hardware-aware planetary optimization.
 
 Run any script with `python <script>` to see it in action.
 

--- a/quantum-cea-dashboard.tsx
+++ b/quantum-cea-dashboard.tsx
@@ -1,3 +1,4 @@
+// Created by Jason DeLooze for Locally Sovereign Sustainability (Open Source) osce@duck.com
 import React, { useState, useEffect } from 'react';
 import { Heart, Brain, Leaf, Activity, Users, AlertCircle, TrendingUp } from 'lucide-react';
 

--- a/quantum-cea-philosophy.md
+++ b/quantum-cea-philosophy.md
@@ -1,3 +1,4 @@
+Created by Jason DeLooze for Locally Sovereign Sustainability (Open Source) osce@duck.com
 # Living Quantum CEA - Philosophy & Implementation Guide
 
 ## Vision Statement

--- a/src/osce/__init__.py
+++ b/src/osce/__init__.py
@@ -2,6 +2,7 @@
 
 from . import hardware
 from .hardware import *
+from .core import LivingQuantumMonitor, PlanetaryOptimizerV3
 
 class Node:
     """Simple representation of a hardware node."""
@@ -63,4 +64,9 @@ class Environment:
             'plugins': self.plugins,
         }
 
-__all__ = ['Environment', 'Node'] + hardware.__all__
+__all__ = [
+    'Environment',
+    'Node',
+    'LivingQuantumMonitor',
+    'PlanetaryOptimizerV3',
+] + hardware.__all__

--- a/src/osce/api/__init__.py
+++ b/src/osce/api/__init__.py
@@ -1,0 +1,4 @@
+"""API helpers for OSCE."""
+from .federation import FederatedNode
+
+__all__ = ['FederatedNode']

--- a/src/osce/api/federation.py
+++ b/src/osce/api/federation.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+@dataclass
+class FederatedNode:
+    """Minimal representation of a federated node."""
+    node_id: str
+    address: str

--- a/src/osce/core/__init__.py
+++ b/src/osce/core/__init__.py
@@ -1,0 +1,10 @@
+"""Core modules for OSCE."""
+from .base import OSCEModule
+from .living_quantum_monitor import LivingQuantumMonitor
+from .planetary_optimizer_v3 import PlanetaryOptimizerV3
+
+__all__ = [
+    'OSCEModule',
+    'LivingQuantumMonitor',
+    'PlanetaryOptimizerV3',
+]

--- a/src/osce/core/base.py
+++ b/src/osce/core/base.py
@@ -1,0 +1,9 @@
+class OSCEModule:
+    """Minimal base class for OSCE core modules."""
+    def __init__(self, config=None):
+        self.config = config or {}
+        self.env = None
+
+    async def initialize(self):
+        """Optional async initialization hook"""
+        pass

--- a/src/osce/core/living_quantum_monitor.py
+++ b/src/osce/core/living_quantum_monitor.py
@@ -1,4 +1,5 @@
 # modules/quantum_cea/living_quantum_monitor.py
+# Created by Jason DeLooze for Locally Sovereign Sustainability (Open Source) osce@duck.com
 """
 Living Quantum CEA Monitor - Phase 1 Implementation
 Evidence-led monitoring and mapping for biological quantum computing

--- a/src/osce/core/planetary_optimizer_v3.py
+++ b/src/osce/core/planetary_optimizer_v3.py
@@ -1,4 +1,5 @@
 # modules/climate_adaptation/planetary_optimizer_v3.py
+# Created by Jason DeLooze for Locally Sovereign Sustainability (Open Source) osce@duck.com
 """
 OSCE Planetary Optimizer v3 - Enhanced with Production HAL Integration
 Distributed optimization with secure hardware abstraction

--- a/src/osce/ml/__init__.py
+++ b/src/osce/ml/__init__.py
@@ -1,0 +1,4 @@
+"""ML helpers for OSCE."""
+from .optimization import MultiObjectiveOptimizer
+
+__all__ = ['MultiObjectiveOptimizer']

--- a/src/osce/ml/optimization.py
+++ b/src/osce/ml/optimization.py
@@ -1,0 +1,4 @@
+class MultiObjectiveOptimizer:
+    """Placeholder multi-objective optimizer."""
+    def optimize(self, objectives):
+        return {}

--- a/src/osce/utils/__init__.py
+++ b/src/osce/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utility helpers for OSCE."""
+from .logging import get_logger
+
+__all__ = ['get_logger']

--- a/src/osce/utils/logging.py
+++ b/src/osce/utils/logging.py
@@ -1,0 +1,5 @@
+import structlog
+
+def get_logger(name: str):
+    """Return a structlog logger."""
+    return structlog.get_logger(name)


### PR DESCRIPTION
## Summary
- add author headers to the new open source modules
- expose `LivingQuantumMonitor` and `PlanetaryOptimizerV3` via `osce.core`
- add minimal `osce` utility, api, ml packages
- update README with module references

## Testing
- `python -m pytest -q`